### PR TITLE
web: Fixed the web project tests

### DIFF
--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 import { ChatComponent } from './components/chat/chat.component';
 
-const routes: Routes = [
+export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: ':channel', component: ChatComponent },
 ];

--- a/web/src/app/app.component.spec.ts
+++ b/web/src/app/app.component.spec.ts
@@ -1,17 +1,46 @@
 import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BlockUI, NgBlockUI, BlockUIModule } from 'ng-block-ui';
+import { CryptoService } from './services/crypto.service';
+import { routes } from './app-routing.module'
+import { Router } from '@angular/router';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MatSnackBar } from '@angular/material';
+
+import { HomeComponent } from './components/home/home.component';
+import { ChatComponent } from './components/chat/chat.component';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
+  let router: Router;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule.withRoutes(routes),
+        BlockUIModule.forRoot({
+          message: 'Loading..'
+        }),
+        FormsModule,
+        ReactiveFormsModule
       ],
       declarations: [
-        AppComponent
+        AppComponent,
+        HomeComponent,
+        ChatComponent
       ],
+      providers: [
+        CryptoService,
+        { provide: MatSnackBar, value: {} }
+      ],
+      schemas: [
+        CUSTOM_ELEMENTS_SCHEMA
+      ]
     }).compileComponents();
+
+    router = TestBed.get(Router)
+    router.initialNavigation();
   }));
 
   it('should create the app', () => {
@@ -20,16 +49,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'web'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('web');
-  });
-
   it('should render title in a h1 tag', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to web!');
+    expect(compiled.querySelector('h1').textContent).toEqual('Secure chat on your computer or smartphone');
   });
 });

--- a/web/src/app/components/chat/chat.component.spec.ts
+++ b/web/src/app/components/chat/chat.component.spec.ts
@@ -1,4 +1,12 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA, MatSnackBar } from '@angular/material';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CryptoService } from '../../services/crypto.service';
+import { ChatService } from '../../services/chat.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WebSocketService } from 'src/app/services/webSocket.service';
+import { User } from 'src/app/models';
 
 import { ChatComponent } from './chat.component';
 
@@ -7,8 +15,24 @@ describe('ChatComponent', () => {
   let fixture: ComponentFixture<ChatComponent>;
 
   beforeEach(async(() => {
+    const chatServiceStub = new ChatService(new WebSocketService(), new CryptoService());
+    chatServiceStub.setUser(new User('testuser', 1));
+
     TestBed.configureTestingModule({
-      declarations: [ ChatComponent ]
+      declarations: [ ChatComponent ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        CryptoService,
+        { provide: ChatService, useValue: chatServiceStub },
+        { provide: MatDialog, useValue: {} },
+        { provide: MatSnackBar, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useValue: [] },
+      ],
     })
     .compileComponents();
   }));

--- a/web/src/app/components/dialog-user/dialog-user.component.spec.ts
+++ b/web/src/app/components/dialog-user/dialog-user.component.spec.ts
@@ -1,4 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 
 import { DialogUserComponent } from './dialog-user.component';
 
@@ -8,9 +10,13 @@ describe('DialogUserComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DialogUserComponent ]
-    })
-    .compileComponents();
+      declarations: [ DialogUserComponent ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+      providers: [
+        { provide: MatDialogRef, value: {} },
+        { provide: MAT_DIALOG_DATA, value: [] }
+      ]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/web/src/app/components/home/home.component.spec.ts
+++ b/web/src/app/components/home/home.component.spec.ts
@@ -1,4 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { RouterTestingModule } from '@angular/router/testing';
+import { CryptoService } from 'src/app/services/crypto.service';
+import { MatSnackBar } from '@angular/material';
 
 import { HomeComponent } from './home.component';
 
@@ -8,7 +12,16 @@ describe('HomeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HomeComponent ]
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule
+      ],
+      declarations: [ HomeComponent ],
+      providers: [
+        CryptoService,
+        { provide: MatSnackBar, useValue: {} },
+      ]
     })
     .compileComponents();
   }));


### PR DESCRIPTION
Fixes issue #2 

Fixed two app component tests and removed one that cannot work properly.
Fixed chat component test.
Fixed dialog user component test.
Fixed home component test.

I had to remove the `AppComponent should have as title 'web'` test because the component does not have a title and the page title is not set in any of the components. The test can be added when there is some way of setting the page title.