### PR TITLE
server: remove warning on private implicit val

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -18,7 +18,8 @@ scalacOptions ++= Seq(
   "-Ywarn-numeric-widen",
   "-Ywarn-value-discard",
   "-Ywarn-unused",
-  "-Ywarn-unused-import"
+  "-Ywarn-unused-import",
+  "-Ywarn-macros:after"
 )
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
This pull request removes parts of the server warning (Related to Issue #4 ).


### Warnings.
```
[warn]  [E1] app/controllers/ChannelsController.scala
[warn]       private val messageFormat in object ChannelsController is never used
[warn]       L38:  private implicit val messageFormat: Format[Message] = wrapperFormat[Message, Base64String](Message.apply, _.base64)
[warn]       L38:                       ^
[warn]  [E2] app/controllers/ChannelsController.scala
[warn]       private val channelNameFormat in object ChannelsController is never used
[warn]       L57:  private implicit val channelNameFormat: Format[Channel.Name] = safeWrapperFormat[Channel.Name, String](Channel.Name.from, _.string)
[warn]       L57:                       ^
[warn]  [E3] app/controllers/ChannelsController.scala
[warn]       private val channelSecretFormat in object ChannelsController is never used
[warn]       L58:  private implicit val channelSecretFormat: Format[Channel.Secret] = wrapperFormat[Channel.Secret, String](Channel.Secret.apply, _.string)
[warn]       L58:                       ^
[warn]  [E4] app/controllers/ChannelsController.scala
[warn]       private val peerFormat in object ChannelsController is never used
[warn]       L60:  private implicit val peerFormat: Format[Peer] = new Format[Peer] {
[warn]       L60:   
```     

### Solution
Those warnings seem false positive and if you remove the code, it becomes compile error.
By adding `-Ywarn-macros:after` option,  you can remove the warnings.

Reference
https://github.com/scala/bug/issues/10599